### PR TITLE
Initial implementation of Mayhem for redb

### DIFF
--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -1,0 +1,61 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  PROJECTNAME: redb
+  MAYHEMFILE: Mayhem/fuzz_redb.mayhemfile
+
+jobs:
+  build:
+    name: '${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.mayhem
+
+      - name: Start analysis for fuzz_redb
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/Dockerfile.mayhem
+++ b/Dockerfile.mayhem
@@ -1,0 +1,19 @@
+# Use Rust to build
+FROM rustlang/rust:nightly as builder
+
+# Add source code to the build stage.
+ADD . /redb
+WORKDIR /redb
+
+RUN cargo install cargo-fuzz
+
+# BUILD INSTRUCTIONS
+WORKDIR /redb/fuzz
+RUN cargo +nightly fuzz build fuzz_redb
+# Output binaries are placed in /redb/fuzz/target/x86_64-unknown-linux-gnu/release/
+
+# Package Stage -- we package for a plain Ubuntu machine
+FROM --platform=linux/amd64 ubuntu:20.04
+
+# Copy the binary from the build stage to an Ubuntu docker image
+COPY --from=builder /redb/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_redb /

--- a/Mayhem/fuzz_redb.mayhemfile
+++ b/Mayhem/fuzz_redb.mayhemfile
@@ -1,0 +1,5 @@
+project: redb
+target: fuzz_redb
+
+cmds:
+  - cmd: /fuzz_redb


### PR DESCRIPTION
Added Mayhem integration for `redb`. This integration was straightforward, as the project is already fuzzed with LibFuzzer. A `Dockerfile` was created to create the fuzzing image, while a `Mayhemfile` and YAML file were created to perform the Mayhem GitHub action.